### PR TITLE
Remove unsupported `edge` argument from `GPIO.add_event_callback` in `change` function

### DIFF
--- a/gpiocrust/raspberry_pi.py
+++ b/gpiocrust/raspberry_pi.py
@@ -123,7 +123,7 @@ class InputPin(object):
         def wrapped(pin):
             fn(self.value)
 
-        GPIO.add_event_callback(self._pin, wrapped, _edge_to_rpi_edge[edge])
+        GPIO.add_event_callback(self._pin, wrapped)
 
     def wait_for_edge(self):
         """


### PR DESCRIPTION
This argument seems to be invalid and does not show up in the latest GPIO source.